### PR TITLE
[YD-2369] Bump up YDS Android SDK libraries to 2.3.2 & YDS RN to 1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ And update your release build command line to enable it:
 ```
 
 ### Release build configuration
-If you're using *Proguard* or other obfuscation tool, please, add these configuration rules to your proguard-rules.pro file:
+If you're using **Proguard** or other obfuscation tool, add the following configuration rules to your proguard-rules.pro file:
 ```groovy
 -keep class com.yoti.** { *; }
 -keep class com.microblink.** { *; }

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ buildTypes {
 }
 
 ```
+If you're using [Firebase Performance Monitoring](https://rnfirebase.io/perf/usage) you'll need to disable it for debug built variant. One way to do this is including this flag in your `gradle.properties` file:
+```
+firebasePerformanceInstrumentationEnabled=false
+
+```
+And update your release build command line to enable it:
+```
+./gradlew assembleRelease -PfirebasePerformanceInstrumentationEnabled=true
+``` 
 
 Depending on your Android project setup and version of React Native, you
 may encounter the following error during your build process:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you're using CocoaPods, navigate to your `ios` and update your `Podfile`:
 
 ```diff
   pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
-+  `pod 'react-native-yoti-doc-scan', :path => '../node_modules/react-native-yoti-doc-scan/react-native-yoti-doc-scan.podspec'`
++ `pod 'react-native-yoti-doc-scan', :path => '../node_modules/react-native-yoti-doc-scan/react-native-yoti-doc-scan.podspec'`
 end
 ```
 
@@ -50,13 +50,13 @@ If autolinking fails, refer to the [troubleshooting instructions](#troubleshooti
 
 Add microblink to your repositories in the root build.gradle file (`android/build.gradle`):
 
-```diff
+```groovy
 allprojects {
     repositories {
-+     mavenCentral()
-+     maven { url 'https://maven.microblink.com' }
-+     maven { url "https://jitpack.io" }
-      ...
+        mavenCentral()
+        maven { url 'https://maven.microblink.com' }
+        maven { url "https://jitpack.io" }
+        ...
     }
     ...
 }
@@ -65,10 +65,10 @@ allprojects {
 
 Add this configuration for the debug build type to your `buildTypes` block (`android/app/build.gradle`):
 
-```diff
+```groovy
 buildTypes {
     debug {
-+     matchingFallbacks = ['release']
+        matchingFallbacks = ['release']
       ...
     }
     ...
@@ -76,14 +76,29 @@ buildTypes {
 
 ```
 If you're using [Firebase Performance Monitoring](https://rnfirebase.io/perf/usage) you'll need to disable it for debug built variant. One way to do this is including this flag in your `gradle.properties` file:
-```
+
+```groovy
 firebasePerformanceInstrumentationEnabled=false
 
 ```
 And update your release build command line to enable it:
-```
+
+```groovy
 ./gradlew assembleRelease -PfirebasePerformanceInstrumentationEnabled=true
-``` 
+
+```
+
+### Release build configuration
+If you're using *Proguard* or other obfuscation tool, please, add these configuration rules to your proguard-rules.pro file:
+```groovy
+-keep class com.yoti.** { *; }
+-keep class com.microblink.** { *; }
+-keep class com.microblink.**$* { *; }
+-dontwarn com.microblink.**
+-keep class com.facetec.zoom.** { *; }
+-dontwarn javax.annotation.Nullable
+```
+
 
 Depending on your Android project setup and version of React Native, you
 may encounter the following error during your build process:
@@ -92,19 +107,18 @@ may encounter the following error during your build process:
 
 Resolve by adding the following packaging options to your `android` block (`android/app/build.gradle`):
 
-```diff
+```groovy
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     
-+   packagingOptions {
-+     pickFirst 'lib/x86/libc++_shared.so'
-+     pickFirst 'lib/x86_64/libjsc.so'
-+     pickFirst 'lib/arm64-v8a/libjsc.so'
-+     pickFirst 'lib/arm64-v8a/libc++_shared.so'
-+     pickFirst 'lib/x86_64/libc++_shared.so'
-+     pickFirst 'lib/armeabi-v7a/libc++_shared.so'
-+   }
-
+    packagingOptions {
+        pickFirst 'lib/x86/libc++_shared.so'
+        pickFirst 'lib/x86_64/libjsc.so'
+        pickFirst 'lib/arm64-v8a/libjsc.so'
+        pickFirst 'lib/arm64-v8a/libc++_shared.so'
+        pickFirst 'lib/x86_64/libc++_shared.so'
+        pickFirst 'lib/armeabi-v7a/libc++_shared.so'
+    }
     ...
 
 ```
@@ -179,10 +193,10 @@ Android linking is performed in 3 steps:
 
 Add the following to your settings.gradle file as a new entry before the last line which has `include ':app'`:
 
-```diff
-+   include ':react-native-yoti-doc-scan'
-+   project(':react-native-yoti-doc-scan').projectDir = new
-+   File(rootProject.projectDir, '../node_modules/react-native-yoti-doc-scan/src/android')
+```groovy
+    include ':react-native-yoti-doc-scan'
+    project(':react-native-yoti-doc-scan').projectDir = new
+    File(rootProject.projectDir, '../node_modules/react-native-yoti-doc-scan/src/android')
 
     include ':app'
 ```
@@ -191,17 +205,17 @@ Add the following to your settings.gradle file as a new entry before the last li
 
 Find the `dependencies` block in your build.gradle file and add `implementation project(':react-native-yoti-doc-scan')`:
 
-```diff
+```groovy
 dependencies {
-   ...
-+   implementation project(':react-native-yoti-doc-scan')
+    ...
+    implementation project(':react-native-yoti-doc-scan')
 }
 ```
 
 
 #### android/app/src/main/java/..../MainApplication.java
 
-Add an import for the package:
+Add this import for the package:
 
 ```diff
 import android.app.Application;

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,8 +38,8 @@ android {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan:2.3.1'
-    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-liveness-zoom:2.3.1'
+    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan:2.3.2'
+    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-liveness-zoom:2.3.2'
 }
 
 allprojects {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 21)
         targetSdkVersion safeExtGet('targetSdkVersion', 29)
-        versionCode 120
-        versionName "1.2.0"
+        versionCode 121
+        versionName "1.2.1"
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }
@@ -38,8 +38,8 @@ android {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan:2.3.0'
-    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-liveness-zoom:2.3.0'
+    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan:2.3.1'
+    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-liveness-zoom:2.3.1'
 }
 
 allprojects {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -95,7 +95,7 @@ def enableSeparateBuildPerCPUArchitecture = false
 /**
  * Run Proguard to shrink the Java bytecode in release builds.
  */
-def enableProguardInReleaseBuilds = false
+def enableProguardInReleaseBuilds = true
 
 /**
  * The preferred build flavor of JavaScriptCore.

--- a/example/android/app/proguard-rules.pro
+++ b/example/android/app/proguard-rules.pro
@@ -8,3 +8,9 @@
 #   http://developer.android.com/guide/developing/tools/proguard.html
 
 # Add any project specific keep options here:
+-keep class com.yoti.** { *; }
+-keep class com.microblink.** { *; }
+-keep class com.microblink.**$* { *; }
+-dontwarn com.microblink.**
+-keep class com.facetec.zoom.** { *; }
+-dontwarn javax.annotation.Nullable

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@getyoti/react-native-yoti-doc-scan",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "Yoti Doc Scan for React Native",
     "main": "YotiDocScan.js",
     "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
Upgrade Android libraries to 2.3.2 version & [Firebase Performance](https://rnfirebase.io/perf/usage) compatibility 

[JIRA](https://lampkicking.atlassian.net/browse/YD-2369)

B&T 

- Build sample project: follow instructions in example/README.md
- Setup Firebase Performance plugin: https://rnfirebase.io/perf/usage

- [x] Debug build - Document & Liveness flow passes:
1. Add this line to gradle.properties 
```
firebasePerformanceInstrumentationEnabled=false
```
2. Run Android example executing `yarn run android` or from Android Studio (open example app):
3. You can pass Doc. auth & Liveness flows.

- [x] Release build - Document & Liveness flow passes:
1. Remove this line from gradle.properties 
```
firebasePerformanceInstrumentationEnabled=false
```
2. Run sample app **RELEASE BUILD variant** 
3. You can pass Doc. auth & Liveness flows.
