### PR TITLE
[YD-2611] Android SDK Upgrade to 2.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Import the SDK with:
 import YotiDocScan from '@getyoti/react-native-yoti-doc-scan;
 ```
 
-Call the `startSession` method with your session Id and client session token.
+Call the `startSession` method with your session Id and client session token. 
 The method accepts two callbacks: one invoked on success and the other when the result is a failure.
 
 ```javascript
@@ -151,29 +151,37 @@ The method accepts two callbacks: one invoked on success and the other when the 
     );
   }}
 ```
+Optionally, you can specify Android request code. If not, by default it is set to 9001:
+```javascript
+    YotiDocScan.setRequestCode(8888);
+```
 
 Your callbacks will receive a consistent response with two parameters: `code` (number) and `description` (string).
 The `code` is always populated with one of the values in the results table below.
 The `description` is not guaranteed to always have a value and as such your business logic should not rely on it.
 
-Code | Description | Retry possible (same session)
-:-- | :-- | :--
-1000 | No error occurred. The user cancelled the session | Yes
-2000 | Unauthorised request (wrong or expired session token) | Yes
-2001 | Session not found | Yes
-2002 | Session expired | Yes
-2003 | SDK launched without session Token | Yes
-2004 | SDK launched without session ID | Yes
-3000 | Yoti's services are down or unable to process the request | Yes
-3001 | An error occurred during a network request | Yes
-3002 | User has no network | Yes
-4000 | The user did not grant permission to the camera | Yes
-5000 | The user's camera was not found and file upload is not allowed | No
-5002 | No more local tries for the liveness flow | Yes
-5003 | SDK is out-of-date, please update the SDK to the latest version | No
-5004 | An unexpected internal error occurred | No
-5005 | An unexpected document capture error occurred | No
-5006 | An unexpected liveness capture error occurred | No
+
+| Code              | Message                      | Retry possible for the same session                    |
+| ----------------- | ---------------------------- | ---------------------------------- |
+| 0                 | Result with success          | No                                 |
+| 1000              | No error occurred - the end-user cancelled the session for an unknown reason           | Yes |
+| 2000              | Unauthorised request (wrong or expired session token)           | Yes |
+| 2001              | Session not found           | Yes |
+| 2003              | SDK launched without session Token           | Yes |
+| 2004              | SDK launched without session ID           | Yes |
+| 3000              | Yoti's services are down or unable to process the request           | Yes |
+| 3001              | An error occurred during a network request          | Yes |
+| 3002              | User has no network          | Yes |
+| 4000              | The user did not grant permissions to the camera          | Yes |
+| 5000              | No camera (when user's camera was not found and file upload is not allowed)          | No |
+| 5002              | No more local tries for the liveness flow          | Yes |
+| 5003              | SDK is out-of-date - please update the SDK to the latest version          | No |
+| 5004              | Unexpected internal error          | No |
+| 5005              | Unexpected document scanning error          | No |
+| 5006              | Unexpected liveness error          | No |
+| 6000              | Document Capture dependency not found error          | No |
+| 6001              | Liveness Zoom dependency not found error          | No |
+| 6002              | Supplementary document dependency not found error          | No |
 
 ## Troubleshooting
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,9 +38,9 @@ android {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan:2.4.0'
-    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan-sup:2.4.0'
-    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-liveness-zoom:2.4.0'
+    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan:2.5.0'
+    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan-sup:2.5.0'
+    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-liveness-zoom:2.5.0'
 }
 
 allprojects {

--- a/android/src/main/java/com/yoti/reactnative/docscan/RNYotiDocScanModule.java
+++ b/android/src/main/java/com/yoti/reactnative/docscan/RNYotiDocScanModule.java
@@ -44,7 +44,7 @@ public class RNYotiDocScanModule extends ReactContextBaseJavaModule {
     RNYotiDocScanModule(ReactApplicationContext reactContext) {
         super(reactContext);
         reactContext.addActivityEventListener((mActivityEventListener));
-        mYotiSdk = new YotiSdk(reactContext);
+        mYotiSdk = new YotiSdk(reactContext).configureReactNativeClient();
     }
 
     @Override

--- a/android/src/main/java/com/yoti/reactnative/docscan/RNYotiDocScanModule.java
+++ b/android/src/main/java/com/yoti/reactnative/docscan/RNYotiDocScanModule.java
@@ -20,11 +20,12 @@ public class RNYotiDocScanModule extends ReactContextBaseJavaModule {
     private YotiSdk mYotiSdk;
     private Callback mErrorCallback;
     private Callback mSuccessCallback;
+    private int mRequestCode = YOTI_SDK_REQUEST_CODE;
 
     private final ActivityEventListener mActivityEventListener = new BaseActivityEventListener() {
         @Override
         public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent intent) {
-            if (requestCode != YOTI_SDK_REQUEST_CODE) {
+            if (requestCode != mRequestCode) {
                 return;
             }
 
@@ -52,6 +53,11 @@ public class RNYotiDocScanModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void setRequestCode(int requestCode) {
+        mRequestCode = requestCode;
+    }
+
+    @ReactMethod
     public void startSession(String sessionId, String clientSessionToken, Callback successCallback, Callback errorCallback) {
         mErrorCallback = errorCallback;
         mSuccessCallback = successCallback;
@@ -60,7 +66,7 @@ public class RNYotiDocScanModule extends ReactContextBaseJavaModule {
             mErrorCallback.invoke("E_ACTIVITY_DOES_NOT_EXIST");
             return;
         }
-        boolean success = mYotiSdk.setSessionId(sessionId).setClientSessionToken(clientSessionToken).configureReactNativeClient().start(currentActivity);
+        boolean success = mYotiSdk.setSessionId(sessionId).setClientSessionToken(clientSessionToken).start(currentActivity, mRequestCode);
         if (!success) {
             int code = mYotiSdk.getSessionStatusCode();
             String description = mYotiSdk.getSessionStatusDescription();

--- a/android/src/main/java/com/yoti/reactnative/docscan/RNYotiDocScanModule.java
+++ b/android/src/main/java/com/yoti/reactnative/docscan/RNYotiDocScanModule.java
@@ -60,7 +60,7 @@ public class RNYotiDocScanModule extends ReactContextBaseJavaModule {
             mErrorCallback.invoke("E_ACTIVITY_DOES_NOT_EXIST");
             return;
         }
-        boolean success = mYotiSdk.setSessionId(sessionId).setClientSessionToken(clientSessionToken).start(currentActivity);
+        boolean success = mYotiSdk.setSessionId(sessionId).setClientSessionToken(clientSessionToken).configureReactNativeClient().start(currentActivity);
         if (!success) {
             int code = mYotiSdk.getSessionStatusCode();
             String description = mYotiSdk.getSessionStatusDescription();

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -148,6 +148,7 @@ export default () => {
                       setCode(code)
                       setDescription(description)
                     }
+                    YotiDocScan.setRequestCode(9999); // Optional: Android request Code customisation
                     YotiDocScan.startSession(sessionId, clientSessionToken, onSuccess, onError);
                   }}
                   title="START SESSION"

--- a/ios/RNYotiDocScanManager.m
+++ b/ios/RNYotiDocScanManager.m
@@ -22,6 +22,11 @@ NSInteger const kYotiSuccessStatusCode = 0;
 
 RCT_EXPORT_MODULE(RNYotiDocScan);
 
+RCT_EXPORT_METHOD(setRequestCode:(NSNumber * _Nonnull)requestCode) {
+    // Nothing to do here: just to maintain compatibility with Android
+    // Both OS need to export same methods (check App.js call to startSession)
+}
+
 RCT_EXPORT_METHOD(startSession:(NSString *)sessionId clientSessionToken:(NSString *)clientSessionToken successCallback:(RCTResponseSenderBlock)successCallback errorCallback:(RCTResponseSenderBlock)errorCallback)
 {
     self.sessionID = sessionId;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@getyoti/react-native-yoti-doc-scan",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "description": "Yoti Doc Scan for React Native",
     "main": "YotiDocScan.js",
     "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
- Upgrade Android SDK to 2.5.0 

- Configure React Native initialisation client: perform `configureReactNativeClient` call to configure native SDK as a React Native client when YDS is initialised.

- Configure RN entry point to use custom Activity request code

[JIRA](https://lampkicking.atlassian.net/browse/YD-2611)