### PR TITLE
[Task] DEP-173: Support v2.5.0 of the iOS SDK

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 21)
         targetSdkVersion safeExtGet('targetSdkVersion', 29)
-        versionCode 140
-        versionName "1.4.0"
+        versionCode 150
+        versionName "1.5.0"
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }

--- a/example/ios/example.xcodeproj/project.pbxproj
+++ b/example/ios/example.xcodeproj/project.pbxproj
@@ -858,7 +858,7 @@
 				INFOPLIST_FILE = example/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -888,7 +888,7 @@
 				INFOPLIST_FILE = example/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@getyoti/react-native-yoti-doc-scan",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "description": "Yoti Doc Scan for React Native",
     "main": "YotiDocScan.js",
     "license": "SEE LICENSE IN LICENSE",

--- a/react-native-yoti-doc-scan.podspec
+++ b/react-native-yoti-doc-scan.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |spec|
   spec.source_files           = "ios/**/*.{h,m}"
   spec.platform               = :ios, "11.0"
   spec.dependency             "React"
-  spec.dependency             "YotiSDKDocument", "2.4.1"
-  spec.dependency             "YotiSDKZoom", "2.4.1"
+  spec.dependency             "YotiSDKDocument", "2.5.0"
+  spec.dependency             "YotiSDKZoom", "2.5.0"
 end


### PR DESCRIPTION
## Purpose
- Support v2.5.0 of the iOS SDK
- Update RN to v1.5.0

## External References (e.g. Jira / Zeplin / Confluence)
[DEP-173](https://lampkicking.atlassian.net/browse/DEP-173)
[YD-2672](https://lampkicking.atlassian.net/browse/YD-2672)

## Approach
- Updated `podspec` to use iOS v2.5.0
- Updated RN to v1.5.0