### PR TITLE
[TASK] Setup Canada DC API call

### DIFF
--- a/android/src/main/java/com/yoti/reactnative/docscan/RNYotiDocScanModule.java
+++ b/android/src/main/java/com/yoti/reactnative/docscan/RNYotiDocScanModule.java
@@ -53,6 +53,11 @@ public class RNYotiDocScanModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void useCanadaService() {
+        mYotiSdk.useCanadaService();
+    }
+
+    @ReactMethod
     public void setRequestCode(int requestCode) {
         mRequestCode = requestCode;
     }
@@ -66,6 +71,7 @@ public class RNYotiDocScanModule extends ReactContextBaseJavaModule {
             mErrorCallback.invoke("E_ACTIVITY_DOES_NOT_EXIST");
             return;
         }
+
         boolean success = mYotiSdk.setSessionId(sessionId).setClientSessionToken(clientSessionToken).start(currentActivity, mRequestCode);
         if (!success) {
             int code = mYotiSdk.getSessionStatusCode();

--- a/ios/RNYotiDocScanManager.m
+++ b/ios/RNYotiDocScanManager.m
@@ -15,7 +15,7 @@ NSInteger const kYotiSuccessStatusCode = 0;
 @property (nonatomic, strong) UIViewController *rootViewController;
 @property (nonatomic, strong) NSString *sessionID;
 @property (nonatomic, strong) NSString *sessionToken;
-@property (nonatomic, assign) ServerLocation serverLocation;
+@property (nonatomic, assign) BOOL setUpCanadaServerLocation;
 @property (nonatomic, strong) RCTResponseSenderBlock errorCallback;
 @property (nonatomic, strong) RCTResponseSenderBlock successCallback;
 @end
@@ -30,7 +30,7 @@ RCT_EXPORT_METHOD(setRequestCode:(NSNumber * _Nonnull)requestCode) {
 }
 
 RCT_EXPORT_METHOD(useCanadaService) {
-    self.serverLocation = ServerLocationCanada;
+    self.setUpCanadaServerLocation = YES;
 }
 
 RCT_EXPORT_METHOD(startSession:(NSString *)sessionId clientSessionToken:(NSString *)clientSessionToken successCallback:(RCTResponseSenderBlock)successCallback errorCallback:(RCTResponseSenderBlock)errorCallback)
@@ -48,15 +48,6 @@ RCT_EXPORT_METHOD(startSession:(NSString *)sessionId clientSessionToken:(NSStrin
     });
 }
 
-// MARK: Init
-
--(id)init {
-     if (self = [super init])  {
-        self.serverLocation = ServerLocationUnitedKingdom;
-     }
-     return self;
-}
-
 // MARK: - Data source delegate
 
 - (NSArray<Class<YotiSDKModule>> * _Nonnull)supportedModuleTypesFor:(YotiSDKNavigationController * _Nonnull)navigationController {
@@ -72,7 +63,11 @@ RCT_EXPORT_METHOD(startSession:(NSString *)sessionId clientSessionToken:(NSStrin
 }
 
 - (ServerLocation)serverLocationFor:(YotiSDKNavigationController * _Nonnull)navigationController {
-    return self.serverLocation;    
+    if (self.setUpCanadaServerLocation) {
+        return ServerLocationCanada;
+    } else {
+        return ServerLocationUnitedKingdom;    
+    }
  }
 
 - (UIColor * _Nonnull)primaryColorFor:(YotiSDKNavigationController * _Nonnull)navigationController {

--- a/ios/RNYotiDocScanManager.m
+++ b/ios/RNYotiDocScanManager.m
@@ -5,6 +5,7 @@
 #import "YotiSDKCore-Swift.h"
 #import "YotiSDKDocument-Swift.h"
 #import "YotiSDKZoom-Swift.h"
+#import "YotiSDKNetwork-Swift.h"
 
 NSInteger const kYotiSuccessStatusCode = 0;
 
@@ -14,6 +15,7 @@ NSInteger const kYotiSuccessStatusCode = 0;
 @property (nonatomic, strong) UIViewController *rootViewController;
 @property (nonatomic, strong) NSString *sessionID;
 @property (nonatomic, strong) NSString *sessionToken;
+@property (nonatomic, assign) ServerLocation serverLocation;
 @property (nonatomic, strong) RCTResponseSenderBlock errorCallback;
 @property (nonatomic, strong) RCTResponseSenderBlock successCallback;
 @end
@@ -25,6 +27,10 @@ RCT_EXPORT_MODULE(RNYotiDocScan);
 RCT_EXPORT_METHOD(setRequestCode:(NSNumber * _Nonnull)requestCode) {
     // Nothing to do here: just to maintain compatibility with Android
     // Both OS need to export same methods (check App.js call to startSession)
+}
+
+RCT_EXPORT_METHOD(useCanadaService) {
+    self.serverLocation = ServerLocationCanada;
 }
 
 RCT_EXPORT_METHOD(startSession:(NSString *)sessionId clientSessionToken:(NSString *)clientSessionToken successCallback:(RCTResponseSenderBlock)successCallback errorCallback:(RCTResponseSenderBlock)errorCallback)
@@ -40,7 +46,15 @@ RCT_EXPORT_METHOD(startSession:(NSString *)sessionId clientSessionToken:(NSStrin
         self.rootViewController = RCTPresentedViewController();
         [self.rootViewController presentViewController:self.yotiSDKNavigationController animated:YES completion:nil];
     });
-    
+}
+
+// MARK: Init
+
+-(id)init {
+     if (self = [super init])  {
+        self.serverLocation = ServerLocationUnitedKingdom;
+     }
+     return self;
 }
 
 // MARK: - Data source delegate
@@ -56,6 +70,10 @@ RCT_EXPORT_METHOD(startSession:(NSString *)sessionId clientSessionToken:(NSStrin
 - (NSString * _Nonnull)sessionTokenFor:(YotiSDKNavigationController * _Nonnull)navigationController {
     return self.sessionToken;
 }
+
+- (ServerLocation)serverLocationFor:(YotiSDKNavigationController * _Nonnull)navigationController {
+    return self.serverLocation;    
+ }
 
 - (UIColor * _Nonnull)primaryColorFor:(YotiSDKNavigationController * _Nonnull)navigationController {
     return [UIColor colorWithRed:34.0/255.0 green:157.0/255.0 blue:255.0/255.0 alpha:1.0];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@getyoti/react-native-yoti-doc-scan",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "description": "Yoti Doc Scan for React Native",
     "main": "YotiDocScan.js",
     "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Provides public API method to use Canada DC: `YotiDocScan.useCanadaService();
This is intentionally not documented because this method is provided for a specific YDS client. 
**If you're not a Yoti member and you see this PR, please, do not use this method unless you're authorised to do so.**

### References

Android client update: [JIRA](https://lampkicking.atlassian.net/browse/YD-2747)
iOS client update: [JIRA](https://lampkicking.atlassian.net/browse/YD-2746)

### Testing
- Create session in Canada DC production and use sessionId and token provided for the following checks:
- Add this configuration call inside App.js file, before `YotiDocScan.startSession(sessionId, clientSessionToken, onSuccess, onError);`
```
YotiDocScan.useCanadaService();
```
- Inside example folder, perform yarn install (remove previous node_modules folder):
- [x] Android client performs Canada DC call:
1. Start Android client via `yarn run android`.
2. Introduce Canada sessionId & session token.
3. Session is started.

- [x] iOS client performs Canada DC call
1. Inside example folder, go to ios folder and execute `pod install`
2. Start iOS client via `yarn run ios`.
2. Introduce Canada sessionId & session token.
3. Session is started.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
