### PR TITLE
[YD-2767] Update to react-native 0.63.4

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,45 +1,19 @@
-platform :ios, '11.0'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+
+platform :ios, '11.0'
 
 target 'example' do
-  pod 'FBLazyVector', :path => "../node_modules/react-native/Libraries/FBLazyVector"
-  pod 'FBReactNativeSpec', :path => "../node_modules/react-native/Libraries/FBReactNativeSpec"
-  pod 'RCTRequired', :path => "../node_modules/react-native/Libraries/RCTRequired"
-  pod 'RCTTypeSafety', :path => "../node_modules/react-native/Libraries/TypeSafety"
-  pod 'React', :path => '../node_modules/react-native/'
-  pod 'React-Core', :path => '../node_modules/react-native/'
-  pod 'React-CoreModules', :path => '../node_modules/react-native/React/CoreModules'
-  pod 'React-Core/DevSupport', :path => '../node_modules/react-native/'
-  pod 'React-RCTActionSheet', :path => '../node_modules/react-native/Libraries/ActionSheetIOS'
-  pod 'React-RCTAnimation', :path => '../node_modules/react-native/Libraries/NativeAnimation'
-  pod 'React-RCTBlob', :path => '../node_modules/react-native/Libraries/Blob'
-  pod 'React-RCTImage', :path => '../node_modules/react-native/Libraries/Image'
-  pod 'React-RCTLinking', :path => '../node_modules/react-native/Libraries/LinkingIOS'
-  pod 'React-RCTNetwork', :path => '../node_modules/react-native/Libraries/Network'
-  pod 'React-RCTSettings', :path => '../node_modules/react-native/Libraries/Settings'
-  pod 'React-RCTText', :path => '../node_modules/react-native/Libraries/Text'
-  pod 'React-RCTVibration', :path => '../node_modules/react-native/Libraries/Vibration'
-  pod 'React-Core/RCTWebSocket', :path => '../node_modules/react-native/'
-
-  pod 'React-cxxreact', :path => '../node_modules/react-native/ReactCommon/cxxreact'
-  pod 'React-jsi', :path => '../node_modules/react-native/ReactCommon/jsi'
-  pod 'React-jsiexecutor', :path => '../node_modules/react-native/ReactCommon/jsiexecutor'
-  pod 'React-jsinspector', :path => '../node_modules/react-native/ReactCommon/jsinspector'
-  pod 'ReactCommon/jscallinvoker', :path => "../node_modules/react-native/ReactCommon"
-  pod 'ReactCommon/turbomodule/core', :path => "../node_modules/react-native/ReactCommon"
-  pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga'
-
-  pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
-  pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
-  pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
+  config = use_native_modules!
+  use_react_native!(:path => config["reactNativePath"])
 
   target 'exampleTests' do
-    inherit! :search_paths
+    inherit! :complete
     # Pods for testing
   end
 
   use_frameworks!
-  use_native_modules!
+  use_native_modules!  
 end
 
 target 'example-tvOS' do

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -13,7 +13,7 @@ target 'example' do
   end
 
   use_frameworks!
-  use_native_modules!  
+  use_native_modules!
 end
 
 target 'example-tvOS' do

--- a/example/ios/example/AppDelegate.m
+++ b/example/ios/example/AppDelegate.m
@@ -12,16 +12,21 @@
 #import <React/RCTRootView.h>
 #import "React/RCTLinkingManager.h"
 #import <React/RCTBundleURLProvider.h>
+#import <React/RCTDevLoadingView.h>
 
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+  
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+  #if RCT_DEV
+    [bridge moduleForClass:[RCTDevLoadingView class]];
+  #endif
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
                                                    moduleName:@"example"
                                             initialProperties:nil];
-
+  
   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];

--- a/example/ios/example/AppDelegate.m
+++ b/example/ios/example/AppDelegate.m
@@ -18,7 +18,6 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-  
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
   #if RCT_DEV
     [bridge moduleForClass:[RCTDevLoadingView class]];

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "0.0.1",
+  "version": "1.6.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "react": "16.9.0",
-    "react-native": "0.61.5",
+    "react-native": "0.63.4",
     "@getyoti/react-native-yoti-doc-scan": "file:.."
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "react": "^16.7.0",
         "react-dom": "^16.7.0",
         "react-hot-loader": "^4.12.20",
-        "react-native": "^0.59.1"
+        "react-native": "^0.63.4"
     },
     "dependencies": {
         "keymirror": "^0.1.1",


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Update to react-native 0.63.4

- Podfile update has been needed because now react-native dependencies
are managed dinamically and it is not needed to specify all of them
in Pofile
- ios example AppDelegate.m update has been needed to fix a new warning
appeared during ios sample execution:
"RCTBridge required dispatch_sync to load RCTDevLoadingView. This may lead to deadlocks"

Related to YD-2767
### References

JIRA: [YD-2767](https://lampkicking.atlassian.net/browse/YD-2767)

### Testing
1. Clone this PR and on terminal:
```
cd example
yarn install
cd ios
pod install
```
- [x] Test Android app, in example directory:
```
yarn run android
```
- Test must include Passport capture with NFC & Liveness Capture. 

- [x] Test iOS app, in example directory:
```
yarn run ios
```
- Test must include Passport capture with NFC & Liveness Capture.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
