### PR TITLE
[DEP-197] Bump version to 1.6.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 21)
         targetSdkVersion safeExtGet('targetSdkVersion', 29)
-        versionCode 160
-        versionName "1.6.0"
+        versionCode 161
+        versionName "1.6.1"
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }
@@ -38,9 +38,9 @@ android {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan:2.6.0'
-    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan-sup:2.6.0'
-    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-liveness-zoom:2.6.0'
+    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan:2.6.1'
+    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan-sup:2.6.1'
+    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-liveness-zoom:2.6.1'
 }
 
 allprojects {

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@getyoti/react-native-yoti-doc-scan",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "description": "Yoti Doc Scan for React Native",
     "main": "YotiDocScan.js",
     "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
## Purpose
- Support v2.6.1+ of SDKs
- Update RN to v1.6.1

## External References (e.g. Jira / Zeplin / Confluence)
[DEP-197](https://lampkicking.atlassian.net/browse/DEP-197)

## Approach
- Updated `build.gradle` for Android to use v2.6.1
- Updated RN wrapper to v1.6.1