### PR TITLE
[TASK][YD-4110] Support v2.8.1 of the Android SDK

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 21)
         targetSdkVersion safeExtGet('targetSdkVersion', 29)
-        versionCode 190
-        versionName "1.9.0"
+        versionCode 191
+        versionName "1.10.0"
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }
@@ -38,10 +38,10 @@ android {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan:2.7.0'
-    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan-sup:2.7.0'
-    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-liveness-zoom:2.7.0'
-    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-facecapture:2.7.0'
+    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan:2.8.1'
+    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan-sup:2.8.1'
+    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-liveness-zoom:2.8.1'
+    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-facecapture:2.8.1'
 }
 
 allprojects {

--- a/example/ios/example.xcodeproj/project.pbxproj
+++ b/example/ios/example.xcodeproj/project.pbxproj
@@ -910,7 +910,7 @@
 				INFOPLIST_FILE = example/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.10.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -940,7 +940,7 @@
 				INFOPLIST_FILE = example/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.10.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/example/ios/example/Info.plist
+++ b/example/ios/example/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.9.0</string>
+	<string>1.10.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/example/package.json
+++ b/example/package.json
@@ -21,7 +21,7 @@
     "babel-jest": "^25.1.0",
     "eslint": "^6.8.0",
     "jest": "^25.1.0",
-    "metro-react-native-babel-preset": "^0.58.0",
+    "metro-react-native-babel-preset": "^0.59.0",
     "react-test-renderer": "16.9.0"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@getyoti/react-native-yoti-doc-scan",
-    "version": "1.9.0",
+    "version": "1.10.0",
     "description": "Yoti Doc Scan for React Native",
     "main": "YotiDocScan.js",
     "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
## Purpose
- Update the Android SDK version to 2.8.1
- Update RN to 1.10.0
- Update `metro-react-native-babel-preset` to 0.59.0. The previous version was causing a crash when running the app on both Android and iOS. More info [here](https://github.com/babel/babel/issues/14139#issuecomment-1011836916).

## External References (e.g. Jira / Zeplin / Confluence)
[YD-4110](https://lampkicking.atlassian.net/browse/YD-4110)