### PR TITLE
[Task] DEP-424 Bump Android SDK version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Continuing with your integration for Android, add the following property and rep
 ```groovy
 buildscript {
     ext {
-        yotiSdkVersion = "3.1.1"
+        yotiSdkVersion = "3.2.0"
     }
 }
 allprojects {

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 29
         targetSdkVersion = 29
-        yotiSdkVersion = "3.1.1"
+        yotiSdkVersion = "3.2.0"
     }
     repositories {
         google()


### PR DESCRIPTION
## Purpose
- Update Android SDK to the latest version [3.2.0](https://github.com/getyoti/yoti-doc-scan-android/releases/tag/v3.2.0)

## External References (e.g. Jira / Zeplin / Confluence)
[DEP-424](https://lampkicking.atlassian.net/browse/DEP-424)

[DEP-424]: https://lampkicking.atlassian.net/browse/DEP-424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ