### PR TITLE
[TASK][DEP-452] Bump Android SDK version to 3.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Continuing with your integration for Android, add the following property and rep
 ```groovy
 buildscript {
     ext {
-        yotiSdkVersion = "3.2.0"
+        yotiSdkVersion = "3.2.2"
     }
 }
 allprojects {

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 29
         targetSdkVersion = 29
-        yotiSdkVersion = "3.2.0"
+        yotiSdkVersion = "3.2.2"
     }
     repositories {
         google()


### PR DESCRIPTION
## Purpose
Update Android SDK to the latest version [3.2.2](https://github.com/getyoti/yoti-doc-scan-android/releases/tag/v3.2.2)

## External References (e.g. Jira / Zeplin / Confluence)
[DEP-452](https://lampkicking.atlassian.net/browse/DEP-452)

[DEP-452]: https://lampkicking.atlassian.net/browse/DEP-452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ