### PR TITLE
null checks

### DIFF
--- a/android/src/main/java/com/yoti/reactnative/docscan/RNYotiDocScanModule.java
+++ b/android/src/main/java/com/yoti/reactnative/docscan/RNYotiDocScanModule.java
@@ -26,11 +26,13 @@ public class RNYotiDocScanModule extends ReactContextBaseJavaModule {
             }
             int code = mYotiSdk.getSessionStatusCode();
             String description = mYotiSdk.getSessionStatusDescription();
-            if (resultCode == Activity.RESULT_OK && code == SESSION_SUCCESS_CODE) {
+            if (resultCode == Activity.RESULT_OK && code == SESSION_SUCCESS_CODE && mSuccessCallback != null) {
                 mSuccessCallback.invoke(code, description);
                 return;
             }
-            mErrorCallback.invoke(code, description);
+            if (mErrorCallback != null) {
+                mErrorCallback.invoke(code, description);
+            }
         }
     };
 


### PR DESCRIPTION
Found a compatibility issue with @react-native-google-signin/google-signin on Android only. When triggering a google sign in, Yoti's ActivityEventListener's onActivityResult gets triggered. However as mSuccessCallback and mErrorCallback are null, the app crashes. Simplest way to fix this is to add a null check before invoking either of them.